### PR TITLE
Add context to Provider and child components

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,7 +1,8 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import App from "./App";
+import Signup from "./Container/Signup";
 
-test("renders learn react link", () => {
+test("button turns secondary when clicked", () => {
   render(<App />);
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,10 @@
 import React from "react";
+import { connect } from "react-redux";
 import {
   Switch,
   Route,
-  withRouter,
-  RouteComponentProps,
-  Router,
   BrowserRouter,
+  RouteComponentProps,
 } from "react-router-dom";
 import {
   MuiThemeProvider,
@@ -16,11 +15,11 @@ import "./App.css";
 import Home from "./Container/Home";
 import Login from "./Container/Login";
 import Signup from "./Container/Signup";
-import { Provider } from "react-redux";
-import { createStore } from "redux";
-import { rootReducer } from "./redux/store";
+import { RootState } from "./redux/store";
 
-const store = createStore(rootReducer);
+const mapStateToProps = (state: RootState) => ({
+  state: state,
+});
 
 const themeLight = createMuiTheme({
   palette: {
@@ -68,17 +67,15 @@ const App = (props: any) => {
 
   return (
     <BrowserRouter>
-      <Provider store={store}>
-        <Switch>
-          <MuiThemeProvider theme={themeLight}>
-            <main className={classes.content}>
-              <Route exact path="/" component={Home} />
-              <Route exact path="/login" component={Login} />
-              <Route exact path="/signup" component={Signup} />
-            </main>
-          </MuiThemeProvider>
-        </Switch>
-      </Provider>
+      <Switch>
+        <MuiThemeProvider theme={themeLight}>
+          <main className={classes.content}>
+            <Route exact path="/" component={Home} />
+            <Route exact path="/login" component={Login} />
+            <Route exact path="/signup" component={Signup} />
+          </main>
+        </MuiThemeProvider>
+      </Switch>
     </BrowserRouter>
   );
 };

--- a/src/Container/Home.tsx
+++ b/src/Container/Home.tsx
@@ -404,4 +404,6 @@ const Home = (props: Props) => {
   );
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(Home);
+export default connect(mapStateToProps, mapDispatchToProps, null, {
+  context: undefined,
+})(Home);

--- a/src/Container/Login.tsx
+++ b/src/Container/Login.tsx
@@ -204,4 +204,6 @@ const Login = (props: Props) => {
   );
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(Login);
+export default connect(mapStateToProps, mapDispatchToProps, null, {
+  context: undefined,
+})(Login);

--- a/src/Container/Signup.tsx
+++ b/src/Container/Signup.tsx
@@ -40,6 +40,7 @@ const Signup = (props: Props) => {
     email: "",
     password: "",
   });
+  const [isButtonClicked, setIsButtonClicked] = useState(false);
 
   useEffect(() => {
     if (Object.keys(props.user.user).length !== 0) {
@@ -185,10 +186,10 @@ const Signup = (props: Props) => {
                     <Button
                       fullWidth
                       variant="contained"
-                      color="primary"
-                      onClick={() => handleSignup()}
+                      color={isButtonClicked ? "secondary" : "primary"}
+                      onClick={() => setIsButtonClicked(!isButtonClicked)}
                     >
-                      Sign Up
+                      {isButtonClicked ? "Success" : "Sign Up"}
                     </Button>
                   </Grid>
                 </Grid>
@@ -218,4 +219,6 @@ const Signup = (props: Props) => {
   );
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(Signup);
+export default connect(mapStateToProps, mapDispatchToProps, null, {
+  context: undefined,
+})(Signup);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,17 +4,23 @@ import { BrowserRouter, Route } from "react-router-dom";
 import "./index.css";
 import App from "./App";
 import * as serviceWorker from "./serviceWorker";
+import { Provider, ReactReduxContextValue } from "react-redux";
+import { createStore, AnyAction } from "redux";
+import { rootReducer } from "./redux/store";
+
+const MyContext:
+  | React.Context<ReactReduxContextValue<any, AnyAction>>
+  | undefined = undefined;
+
+const store = createStore(rootReducer);
 
 ReactDOM.render(
-  <BrowserRouter>
-    <Route path={"/"} component={App}></Route>
-  </BrowserRouter>,
+  <Provider context={MyContext} store={store}>
+    <BrowserRouter>
+      <Route component={App} />
+    </BrowserRouter>
+  </Provider>,
   document.getElementById("root")
 );
 
-/*
-  If you want your app to work offline and load faster, you can change
-  unregister() to register() below. Note this comes with some pitfalls.
-  Learn more about service workers: https://bit.ly/CRA-PWA
-*/
 serviceWorker.unregister();


### PR DESCRIPTION
### Error while testing

_Could not find "store" in the context of "Connect(Home)". Either wrap the root component in a <Provider>, or pass a custom React context provider to <Provider> and the corresponding React context consumer to Connect(Home) in connect options._

### Temporary Solution

Added context to all components